### PR TITLE
Traduzindo mensagens de erro

### DIFF
--- a/apps/api/src/Admin/components/subscription.tsx
+++ b/apps/api/src/Admin/components/subscription.tsx
@@ -68,7 +68,7 @@ const Subscription: FC<ActionProps> = (props) => {
       setSubscripitons(res.data.requests)
     })
     .catch(error => {
-      console.log("DEU RUIM", error)
+      console.error("[Admin Subscription]: ", error)
     })
   }, [])
 
@@ -85,7 +85,7 @@ const Subscription: FC<ActionProps> = (props) => {
         setAnwseredSubs(res.data.requests)
       })
       .catch(error => {
-        console.log("DEU RUIM", error)
+        console.error("[Admin Subscription]: ", error)
       })
     }, [])
 

--- a/apps/api/src/Db/config.test.ts
+++ b/apps/api/src/Db/config.test.ts
@@ -75,7 +75,7 @@ describe('TypeORM config', () => {
       delete process.env.DB_NAME
       delete process.env.DATABASE_URL
       
-      expect(getDbConnConfig).toThrow("Invalid DB config. Check environment variables")
+      expect(getDbConnConfig).toThrow("Configurações de DB inválidas. Confira variáveis de ambiente.")
     })
   })
 

--- a/apps/api/src/Db/config.ts
+++ b/apps/api/src/Db/config.ts
@@ -35,7 +35,7 @@ export const getDbConnConfig: () => PostgresConnectionOptions = () => {
   }
 
   // else, throw
-  throw new Error("Invalid DB config. Check environment variables")
+  throw new Error("Configurações de DB inválidas. Confira variáveis de ambiente.")
 }
 
 export const getTypeOrmConfig = () => {

--- a/apps/api/src/Middlewares/cors.ts
+++ b/apps/api/src/Middlewares/cors.ts
@@ -39,7 +39,7 @@ export const originChecker = (allowedOrigins: RegExp[]) => (origin: string | und
 
   if (!isAllowed) {
     console.log("Rejecter request because of CORS policy.", `allowedOrigins: `, allowedOrigins, `origin: `, origin)
-    const msg = `The CORS policy for this site does not allow access from the specified Origin (${origin})`
+    const msg = `A política CORS para este site não permite acesso da Origem especificada (${origin})`
     return callback(new Error(msg), false)
   }
   return callback(null, true)

--- a/apps/api/src/Middlewares/ensureAuthenticated.ts
+++ b/apps/api/src/Middlewares/ensureAuthenticated.ts
@@ -26,7 +26,7 @@ export default function ensureAuthenticated(
   const authHeader = req.headers.authorization;
 
   if (!authHeader) {
-    return unauthenticatedError(res, "JWT token is missing")
+    return unauthenticatedError(res, "Token JWT não encontrado")
   }
 
   const [, token] = authHeader.split(" ");
@@ -36,12 +36,12 @@ export default function ensureAuthenticated(
     const { id } = decoded as ITokenPayload;
 
     if (!id) {
-      return unauthenticatedError(res, "Invalid JWT token")
+      return unauthenticatedError(res, "JWT inválido")
     }
 
     req.user = { id }
     return next();
   } catch {
-    return unauthenticatedError(res, "Invalid JWT token")
+    return unauthenticatedError(res, "JWT inválido")
   }
 }

--- a/apps/api/src/Middlewares/parseFiles.ts
+++ b/apps/api/src/Middlewares/parseFiles.ts
@@ -56,16 +56,16 @@ export const parseMultedFiles =
     
     const fieldFiles = getFieldFiles(req, fieldName)
     if (fieldFiles.length < min)
-      return badRequestError(res, `Needed at least ${min} files for ${fieldName} field`)
+      return badRequestError(res, `Necessário no mínimo ${min} arquivos para ${fieldName}`)
 
     if (fieldFiles.length > max)
-      return badRequestError(res, `Too many files sent for ${fieldName} field`)
+      return badRequestError(res, `Muitos arquivos enviados para ${fieldName}`)
 
     if (fieldFiles.some(file => file.size > maxSize))
-      return badRequestError(res, `File too big for ${fieldName} field. Maximum file size is ${byteNumToString(maxSize)}`)
+      return badRequestError(res, `Arquivo muito grande para o campo ${fieldName}. O tamanho máximo é ${byteNumToString(maxSize)}`)
 
     if (fieldFiles.some(file => !fileIsOfType(file, type)))
-      return badRequestError(res, `Incorrect filetype for ${fieldName} field`)
+      return badRequestError(res, `Tipo de arquivo inválido para ${fieldName}`)
 
     req.parsedFiles![fieldName as T] = fieldFiles
   }

--- a/apps/api/src/Repository/UserRepository.ts
+++ b/apps/api/src/Repository/UserRepository.ts
@@ -446,7 +446,7 @@ export class UserRepository extends Repository<User> {
     const { secret, expiresIn } = authConfig.jwt;
 
     const user = await this.findOne({ where: { email } });
-    if (!user) throw new Error("No user found");
+    if (!user) throw new Error("Usuário não encontrado");
 
     const token = sign({ id: user.id }, secret, { expiresIn });
     return token;
@@ -456,7 +456,7 @@ export class UserRepository extends Repository<User> {
     const { secret, expiresIn } = authConfig.token;
 
     const user = await this.findOne({ where: { email } });
-    if (!user) throw new Error("No user found");
+    if (!user) throw new Error("Usuário não encontrado");
 
     const token = sign({ id: user.id }, secret, { expiresIn });
     return token;

--- a/apps/api/src/Routes/AnimalExample/CreateAnimal.ts
+++ b/apps/api/src/Routes/AnimalExample/CreateAnimal.ts
@@ -19,10 +19,10 @@ export const CreateAnimal: (deps: CreateAnimalInterface) => RouteHandler<Req<Dee
   } = req.body
 
   // if request body not complete, return 400
-  if (!name || !rank) return badRequestError(res, "Incomplete request body")
+  if (!name || !rank) return badRequestError(res, "Requisição incompleta")
 
   // if request body has wrong types
-  if (typeof name !== 'string' || typeof rank !== 'number') return badRequestError(res, "Invalid request body")
+  if (typeof name !== 'string' || typeof rank !== 'number') return badRequestError(res, "Requisição inválida")
 
   const animal = AnimalExampleRepo.create({ name, rank })
   await AnimalExampleRepo.save(animal)

--- a/apps/api/src/Routes/AnimalExample/index.test.ts
+++ b/apps/api/src/Routes/AnimalExample/index.test.ts
@@ -51,23 +51,23 @@ describe.skip('AnimalExample Router', () => {
   //   it("should 400 with an incomplete AnimalExample in the request body", async (done) => {
   //     const emptyBody = agent
   //       .post("/animal-example/create")
-  //       .send({})   // send incomplete request body
+  //       .send({})   // send Requisição incompleta
   //       .expect('Content-Type', /json/)
-  //       .expect(400, { error: "Incomplete request body" })
+  //       .expect(400, { error: "Requisição incompleta" })
   //       // .then(() => expect(RepoConfig.table.length).toBe(0))
 
   //     const onlyName = agent
   //       .post("/animal-example/create")
-  //       .send({ name: "incomplete" })   // send incomplete request body
+  //       .send({ name: "incomplete" })   // send Requisição incompleta
   //       .expect('Content-Type', /json/)
-  //       .expect(400, { error: "Incomplete request body" })
+  //       .expect(400, { error: "Requisição incompleta" })
   //       // .then(() => expect(RepoConfig.table.length).toBe(0))
 
   //     const onlyRank = agent
   //       .post("/animal-example/create")
-  //       .send({ rank: 12 })   // send incomplete request body
+  //       .send({ rank: 12 })   // send Requisição incompleta
   //       .expect('Content-Type', /json/)
-  //       .expect(400, { error: "Incomplete request body" })
+  //       .expect(400, { error: "Requisição incompleta" })
   //       // .then(() => expect(RepoConfig.table.length).toBe(0))
         
   //     // end test after all tests are done
@@ -81,7 +81,7 @@ describe.skip('AnimalExample Router', () => {
   //       .post("/animal-example/create")
   //       .send({ name: 12, rank: true })
   //       .expect('Content-Type', /json/)
-  //       .expect(400, { error: "Invalid request body" })
+  //       .expect(400, { error: "Requisição inválida" })
   //       .then(() => expect(RepoConfig.table).toHaveLength(0))
   //       .then(() => done())
   //   })

--- a/apps/api/src/Routes/Courses/GetSubscriptionIfExists.ts
+++ b/apps/api/src/Routes/Courses/GetSubscriptionIfExists.ts
@@ -32,12 +32,12 @@ export const GetSubscriptionIfExists: (
   const { id } = req.user ?? {}
   const { course_id } = req.params
 
-  if (!id) return badRequestError(res, "user id missing")
-  if (!course_id) return badRequestError(res, "course id missing")
+  if (!id) return badRequestError(res, "ID de usuário faltando")
+  if (!course_id) return badRequestError(res, "ID de curso faltando")
 
   return RequestRepo.getRequest({ userId: id, courseId: course_id })
     .then(request => fetchedSuccessfully(res, { request, exists: !!request }))
-    .catch(error => unidentifiedError(res, "unknown server error", { error }))
+    .catch(error => unidentifiedError(res, "Erro de servidor desconhecido", { error }))
 }
 
 export default GetSubscriptionIfExists

--- a/apps/api/src/Routes/Courses/ShowCourse.ts
+++ b/apps/api/src/Routes/Courses/ShowCourse.ts
@@ -13,7 +13,7 @@ export const ShowCourse: (
   CourseRepo
 }: GetAllCourserInterface) => async (req, res) => {
   const course = await CourseRepo.findById(req.params.course_id);
-  if (!course) return notFoundError(res, "No course found with that id")
+  if (!course) return notFoundError(res, "Nenhum curso foi encontrado com esse id")
   return fetchedSuccessfully(res, course)
 }
 

--- a/apps/api/src/Routes/Courses/SubscribeToCourse.ts
+++ b/apps/api/src/Routes/Courses/SubscribeToCourse.ts
@@ -31,22 +31,22 @@ export const SubscribeToCourse: (
   const { id } = req.user ?? {}
   const { course_id } = req.params
 
-  if (!id) return badRequestError(res, "user id missing")
-  if (!course_id) return badRequestError(res, "course id missing")
+  if (!id) return badRequestError(res, "ID de usuário faltando")
+  if (!course_id) return badRequestError(res, "ID do curso faltando")
   
   const [user, course] = await Promise.all([UserRepo.findById(id), CourseRepo.findById(course_id)])
 
-  if (!user)        return unauthenticatedError(res, "Not found user with that id" )
-  if (!course)      return notFoundError(res, 'Course not found')
-  if (!user.active) return unauthorizedError(res, "This user didn't confirm his account in the email!!")
-  if (user.banned)  return unauthorizedError(res, "This user is banned")
+  if (!user)        return unauthenticatedError(res, "ID de usuário não encontrado" )
+  if (!course)      return notFoundError(res, 'Curso não encontrado')
+  if (!user.active) return unauthorizedError(res, "Este usuário não confirmou seu endereço de email!!")
+  if (user.banned)  return unauthorizedError(res, "Este usuário está banido")
 
   if (!course.available) return badRequestError(res, "Não pode se inscrever em um curso que não está mais disponível")
   if (!course.has_subscription) return badRequestError(res, "Essa atividade não aceita pedidos de inscrição")
   
   return RequestRepo.createRequest(user, course)
-    .then(() => createdSuccessfully(res, "Request Created"))
-    .catch(() => unidentifiedError(res, "Something went wrong"))
+    .then(() => createdSuccessfully(res, "Requisição feita"))
+    .catch(() => unidentifiedError(res, "Alguma coisa deu errado"))
   }
 
 export default SubscribeToCourse

--- a/apps/api/src/Routes/Session/AskReset.ts
+++ b/apps/api/src/Routes/Session/AskReset.ts
@@ -20,11 +20,11 @@ export const AskReset: (
   const { email } = req.body
 
   if (!email) {
-    return badRequestError(res, "Requisição Incompleta!!")
+    return badRequestError(res, "Requisição incompleta!!")
   }
 
   if (typeof email !== "string") {
-    return badRequestError(res, "Requisição Inválida!!" );
+    return badRequestError(res, "Requisição inválida!!" );
   }
 
   const user = await UserRepo.findByEmail(email);
@@ -38,8 +38,8 @@ export const AskReset: (
   sendPwdResetEmail(user, token)
   
   if (process.env.NODE_ENV === "development")
-    return actionSuccessful(res, { message: "Reset token sent to email!", token });
-  else return actionSuccessful(res, { message: "Reset token sent to email!"});
+    return actionSuccessful(res, { message: "Token de reset enviado para email!", token });
+  else return actionSuccessful(res, { message: "Token de reset enviado para email!"});
 };
 
 export default AskReset;

--- a/apps/api/src/Routes/Session/AskReset.ts
+++ b/apps/api/src/Routes/Session/AskReset.ts
@@ -20,11 +20,11 @@ export const AskReset: (
   const { email } = req.body
 
   if (!email) {
-    return badRequestError(res, "Incomplete request body!!")
+    return badRequestError(res, "Requisição Incompleta!!")
   }
 
   if (typeof email !== "string") {
-    return badRequestError(res, "Invalid request body!!" );
+    return badRequestError(res, "Requisição Inválida!!" );
   }
 
   const user = await UserRepo.findByEmail(email);

--- a/apps/api/src/Routes/Session/CreateSession.ts
+++ b/apps/api/src/Routes/Session/CreateSession.ts
@@ -28,17 +28,17 @@ export const CreateSession: (
   const userDB = await UserRepo.findByEmail(email);
 
   if (!userDB) {
-    return unauthorizedError(res, "Incorrect email/password combination.");
+    return unauthorizedError(res, "Email e/ou senha incorretos");
   }
 
   const passwordMatched = await UserRepo.compareHash(password, userDB.password);
 
   if (!passwordMatched) {
-    return unauthorizedError(res, "Incorrect email/password combination.");
+    return unauthorizedError(res, "Email e/ou senha incorretos");
   }
 
   if (!userDB.active) {
-    return unauthorizedError(res, "Email confimation needed");
+    return unauthorizedError(res, "Email ainda não foi confimado");
   }
 
   const token = await UserRepo.generateToken(email);

--- a/apps/api/src/Routes/Session/CreateSession.ts
+++ b/apps/api/src/Routes/Session/CreateSession.ts
@@ -20,10 +20,10 @@ export const CreateSession: (
   const { email, password } = req.body
 
   if (!email || !password)
-    return badRequestError(res, "Incomplete request body");
+    return badRequestError(res, "Requisição incompleta");
 
   if (typeof email !== "string" || typeof password !== "string")
-    return badRequestError(res, "Invalid request body");
+    return badRequestError(res, "Requisição inválida");
 
   const userDB = await UserRepo.findByEmail(email);
 

--- a/apps/api/src/Routes/Session/EmailConfirmation.ts
+++ b/apps/api/src/Routes/Session/EmailConfirmation.ts
@@ -20,7 +20,7 @@ export const EmailConfirmation: (deps: ConfirmEmailInterface) => RouteHandler<Re
   const user = await UserRepo.findById(userId)
 
   if(!user){
-    return badRequestError(res, "Invalid user")
+    return badRequestError(res, "Usuário Inválido")
   }
   
   user.active = true

--- a/apps/api/src/Routes/Session/ResetPassword.ts
+++ b/apps/api/src/Routes/Session/ResetPassword.ts
@@ -24,11 +24,11 @@ export const ResetPassword: (
   const { password, token } = req.body
 
   if (!token || !password) {
-    return badRequestError(res, "Incomplete request body!!")
+    return badRequestError(res, "Requisição incompleta!!")
   }
 
   if (typeof token !== "string" || typeof password !== "string") {
-    return badRequestError(res, "Invalid request body!!")
+    return badRequestError(res, "Requisição inválida!!")
   }
 
   const decoded = verify(token, authConfig.token.secret);
@@ -51,10 +51,10 @@ export const ResetPassword: (
     user.password = await UserRepo.generateHash(password);
     await UserRepo.save(user);
   } else {
-    return unauthenticatedError(res, "Token is not valid!!")
+    return unauthenticatedError(res, "O token de autenticação não é válido!!")
   }
 
-  return actionSuccessful(res, "Password Changed Sucessfully !!");
+  return actionSuccessful(res, "Senha alterada com sucesso!!");
 };
 
 export default ResetPassword;

--- a/apps/api/src/Routes/Session/index.test.ts
+++ b/apps/api/src/Routes/Session/index.test.ts
@@ -129,7 +129,7 @@ describe('Session Router', () => {
         .post('/sessions/create')
         .send({ email: 'johndoe@email.com', password: '123456' })
         .expect('Content-Type', /json/ )
-        .expect(401, ErrorObj(401, 'Incorrect email/password combination.'))
+        .expect(401, ErrorObj(401, 'Email e/ou senha incorretos'))
         .then(() => {
           done()
         })
@@ -148,7 +148,7 @@ describe('Session Router', () => {
         .post('/sessions/create')
         .send({ name: 'John Doe', email: 'johndoe@email.com', password: '654321' })
         .expect('Content-Type', /json/ )
-        .expect(401, ErrorObj(401, 'Incorrect email/password combination.'))
+        .expect(401, ErrorObj(401, 'Email e/ou senha incorretos'))
         .then(() => {
           done()
         })

--- a/apps/api/src/Routes/Session/index.test.ts
+++ b/apps/api/src/Routes/Session/index.test.ts
@@ -86,19 +86,19 @@ describe('Session Router', () => {
         .post('/sessions/create')
         .send({})
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
       const onlyEmail = agent
         .post('/sessions/create')
         .send({ email: 'johndoe@email.com' })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
       const onlyPassword = agent
         .post('/sessions/create')
         .send({ password: '123456' })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
         Promise
           .all([ emptyBody, onlyEmail, onlyPassword ])
@@ -111,7 +111,7 @@ describe('Session Router', () => {
         .post('/sessions/create')
         .send({ email: 'johndoe@email.com', password: true })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Invalid request body'))
+        .expect(400, ErrorObj(400, 'Requisição inválida'))
         .then(() => {
           done()
         })

--- a/apps/api/src/Routes/User/CreateUser.ts
+++ b/apps/api/src/Routes/User/CreateUser.ts
@@ -32,7 +32,7 @@ export const CreateUser: (
 
   const checkUserExists = await UserRepo.findByEmail(email);
   if (!!checkUserExists)
-    return badRequestError(res, "Email address already exists.");
+    return badRequestError(res, "Esse email já está sendo utilizado.");
 
   try {
     const curriculum = req.parsedFiles?.curriculum ?? [];
@@ -77,11 +77,11 @@ export const CreateUser: (
         let { password: _, ...newUser } = user;
         return createdSuccessfully(res, removeCircularity(newUser));
       })
-      .catch((err) => databaseError(res, "Error trying to create user.", err));
+      .catch((err) => databaseError(res, "Erro ao tentar criar usuário.", err));
   } catch {
     return badRequestError(
       res,
-      "Error trying to create curriculum or profilePicture"
+      "Erro ao enviar currículo, laudo ou foto de perfil. "
     );
   }
 };

--- a/apps/api/src/Routes/User/ResendEmail.ts
+++ b/apps/api/src/Routes/User/ResendEmail.ts
@@ -20,12 +20,12 @@ export const ResendEmail: (
 
   const user = await UserRepo.findByEmail(email)
 
-  if(!user) return databaseError(res, "No user found")
+  if(!user) return databaseError(res, "Nenhum usuário encontrado")
 
   sendConfirmationEmail(user)
 
   return actionSuccessful(res, {
-    message: 'Email sent'
+    message: 'Email enviado'
   })
 
 } 

--- a/apps/api/src/Routes/User/ShowCurrentUser.ts
+++ b/apps/api/src/Routes/User/ShowCurrentUser.ts
@@ -17,9 +17,9 @@ export const ShowCurrentUser: (
   const user = await UserRepo.findById(id ?? "")
 
   if (!user)
-    return unauthenticatedError(res, "Not logged in")
+    return unauthenticatedError(res, "Usuário não autenticado")
   if (!user.active)
-    return unauthorizedError(res, "This user didn't confirm his account in the email!!");
+    return unauthorizedError(res, "Esse usuário não confirmou usa conta pelo email!");
 
   const { password: _, ...userWithoutPassword } = user
 

--- a/apps/api/src/Routes/User/ShowUser.ts
+++ b/apps/api/src/Routes/User/ShowUser.ts
@@ -19,20 +19,20 @@ export const ShowUser: (
   const { id } = req.params;
 
   if (!id) {
-    return badRequestError(res, "Incomplete request param");
+    return badRequestError(res, "Parâmetro de requisição incompleto");
   }
   if (typeof id !== "string") {
-    return badRequestError(res, "Invalid request param");
+    return badRequestError(res, "Parâmetro de requisição inválido");
   }
 
   const user = await UserRepo.findById(id);
 
   if (!user) {
-    return unauthenticatedError(res, "Not found user with that id" );
+    return unauthenticatedError(res, "Usuário com esse ID não encontrado" );
   }
 
   if (!user.active) {
-    return unauthorizedError(res, "This user didn't confirm his account in the email!!");
+    return unauthorizedError(res, "Esse usuário não confirmou a sua conta pelo email!");
   }
 
   let { password: _, ...userQueried } = user;

--- a/apps/api/src/Routes/User/UpdateUser.ts
+++ b/apps/api/src/Routes/User/UpdateUser.ts
@@ -102,11 +102,11 @@ export const UpdateUser: (
         let { password: _, ...newUser } = user;
         return updatedSuccessfully(res, removeCircularity(newUser));
       })
-      .catch((err) => databaseError(res, "Error trying to update user.", err));
+      .catch((err) => databaseError(res, "Erro ao tentar atualizar o usuário.", err));
   } catch {
     return badRequestError(
       res,
-      "Error trying to create curriculum or profilePicture"
+      "Erro tentando enviar currículo, laudo ou foto de perfil"
     );
   }
 };

--- a/apps/api/src/Routes/User/index.test.ts
+++ b/apps/api/src/Routes/User/index.test.ts
@@ -103,25 +103,25 @@ describe('User Router', () => {
         .post('/user')
         .send({})
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
       const onlyName = agent
         .post('/user')
         .send({ name: 'John Doe' })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
       const onlyEmail = agent
         .post('/user')
         .send({ email: 'johndoe@email.com' })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
       const onlyPassword = agent
         .post('/user')
         .send({ password: '123456' })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
 
         Promise
           .all([ emptyBody, onlyName, onlyEmail, onlyPassword ])
@@ -153,7 +153,7 @@ describe('User Router', () => {
         .post('/user')
         .send({ name: 123, email: 'johndoe@email.com', password: true })
         .expect('Content-Type', /json/ )
-        .expect(400, ErrorObj(400, 'Incomplete request body' ))
+        .expect(400, ErrorObj(400, 'Requisição incompleta' ))
         .then(() => {
           expect(mockTable.length).toBe(0)
           done()

--- a/apps/api/src/Utils/catchError.ts
+++ b/apps/api/src/Utils/catchError.ts
@@ -11,6 +11,6 @@ export const catchError = (middleware: Middleware, returnFn?: errorReturnFn, err
   try {
     middleware(req, res, next)
   } catch (error) {
-    errorReturn(res, errorMsg ?? "Unidentified Error.", { error })
+    errorReturn(res, errorMsg ?? "Erro não identificado.", { error })
   }
 }

--- a/apps/api/src/Utils/createTestApp.ts
+++ b/apps/api/src/Utils/createTestApp.ts
@@ -12,7 +12,7 @@ export const createTestApp = (Router: ExpressRouter, baseRoute: string = "/") =>
   // add Router and catcher for unkown route
   app
     .use(baseRoute, Router)
-    .use("*", (_, res) => badRequestError(res, "Route doesn't exist" ))
+    .use("*", (_, res) => badRequestError(res, "Essa rota não existe." ))
   
   return supertest
     .agent(app)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,7 +31,7 @@ Db()
 
   app.use("/", Routes({ conn }))
   app.get('/hello', (_, res) => actionSuccessful(res, { msg: 'world' }))
-  app.use("*", (_, res) => badRequestError(res, "Route doesn't exist" ))
+  app.use("*", (_, res) => badRequestError(res, "Essa rota não existe" ))
 
   // error handling
   app.use(errorHandler)

--- a/apps/client/src/Pages/Error/Mobile/index.tsx
+++ b/apps/client/src/Pages/Error/Mobile/index.tsx
@@ -24,8 +24,12 @@ export const Mobile: FC<Props> = ({ status, message }) => {
       </TopWrapper>
       <MobileRectangle invert={true}>
         <SubtitleText level={2}>
-          Error {status ?? 401}:
-          <br /> {message ?? 'Acesso negado devido a credenciais não válidas.'}
+          {status && (
+            <>
+              Error {status}: <br />
+            </>
+          )}
+          <br /> {message ?? 'Não foi possível carregar essa página.'}
         </SubtitleText>
         <TitleText level={1}>
           Ops...

--- a/apps/client/src/Pages/Error/Web/index.tsx
+++ b/apps/client/src/Pages/Error/Web/index.tsx
@@ -26,9 +26,12 @@ export const Web: FC<Props> = ({ status, message }) => {
             Parece que algo deu errado
           </TitleText>
           <SubtitleText>
-            Error {status ?? 401}:
-            <br />{' '}
-            {message ?? 'Acesso negado devido a credenciais não válidas.'}
+            {status && (
+              <>
+                Error {status}: <br />
+              </>
+            )}
+            {message ?? "Não foi possível carregar essa página."}
           </SubtitleText>
         </TextWrapper>
       </Rectangle2>

--- a/apps/client/src/Pages/Error/index.tsx
+++ b/apps/client/src/Pages/Error/index.tsx
@@ -12,20 +12,13 @@ export interface Props {
 }
 
 export const Error: FC<Props> = ({ errorStatus, errorMessage }) => {
-  const width = useMobile();
+  const Component = useMobile() ? Mobile : Web;
 
-  if (width)
-    return (
-      <Wireframe>
-        <Mobile status={errorStatus} message={errorMessage} />
-      </Wireframe>
-    );
-  else
-    return (
-      <Wireframe>
-        <Web status={errorStatus} message={errorMessage} />
-      </Wireframe>
-    );
+  return (
+    <Wireframe>
+      <Component status={errorStatus} message={errorMessage} />
+    </Wireframe>
+  );
 };
 
 export default Error;

--- a/apps/client/src/Routes/AboutUs/index.tsx
+++ b/apps/client/src/Routes/AboutUs/index.tsx
@@ -9,7 +9,6 @@ const AboutUsPage = lazy(() => import('./AboutUsPage'));
 
 export const AboutUs: Router = ({ match }) => {
   const { path = '/about-us' } = match ?? {};
-
   usePageview({ name: 'sobre', path: path });
 
   return (

--- a/apps/client/src/Routes/Classes/index.tsx
+++ b/apps/client/src/Routes/Classes/index.tsx
@@ -10,7 +10,6 @@ const ClassDetails = lazy(() => import('./ClassDetails'));
 
 export const Classes: Router = ({ match }) => {
   const { path = '/classes' } = match ?? {};
-
   usePageview({ name: 'classes', path });
 
   return (

--- a/apps/client/src/Routes/Observatorio/index.tsx
+++ b/apps/client/src/Routes/Observatorio/index.tsx
@@ -9,7 +9,6 @@ const ObservatorioPage = lazy(() => import('./ObservatorioPage'));
 
 export const Observatorio: Router = ({ match }) => {
   const { path = '/observatorio' } = match ?? {};
-
   usePageview({ name: 'observatorio', path });
 
   return (

--- a/apps/client/src/Routes/PasswordRecover/index.tsx
+++ b/apps/client/src/Routes/PasswordRecover/index.tsx
@@ -10,7 +10,6 @@ const ResetEmail = lazy(() => import('./ResetEmail'));
 
 export const PasswordRecover: Router = ({ match }) => {
   const { path = 'recover' } = match ?? {};
-
   usePageView({ name: 'recuperacao', path });
 
   return (

--- a/libs/server-conn-info/src/index.ts
+++ b/libs/server-conn-info/src/index.ts
@@ -6,8 +6,6 @@ export const protocol = `http`
 export const getApiPort = () => {
   const portEnv = Number(process.env.PORT || "5430")
 
-  console.log(portEnv)
-
   if (isNaN(portEnv))
     throw new Error("PORT environment variable present, but not a number")
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,11 +5318,6 @@
   dependencies:
     dotenv "*"
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/eslint@^8.4.6":
   version "8.4.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.6.tgz#7976f054c1bccfcf514bff0564c0c41df5c08207"
@@ -5495,7 +5490,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3":
+"@types/json-schema@*", "@types/json-schema@^7.0.7":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -5961,48 +5956,75 @@
   resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.13.tgz#21b137ba60841307a3c8a1050d3bf4e63ad561e9"
   integrity sha512-qRyuv+P/1t1JK1rA+elmK1MmCL1BapEzKKfbEhDBV/LMMse4lmhZ/XbgETI39JveDJRpLjmToOI6uFtMW/WR2g==
 
-"@typescript-eslint/eslint-plugin@^2.10.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+"@typescript-eslint/eslint-plugin@^2.10.0", "@typescript-eslint/eslint-plugin@^4.1.1":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    tsutils "^3.17.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+"@typescript-eslint/experimental-utils@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
+  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^2.10.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
+"@typescript-eslint/parser@^2.10.0", "@typescript-eslint/parser@^4.1.1":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
   dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
 
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+"@typescript-eslint/scope-manager@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
+  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
   dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+
+"@typescript-eslint/types@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
+  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/typescript-estree@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
+  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
+  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -8339,15 +8361,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157:
-  version "1.0.30001233"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz"
-  integrity sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg==
-
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001245"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz#45b941bbd833cb0fa53861ff2bae746b3c6ca5d4"
-  integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157, caniuse-lite@^1.0.30001219:
+  version "1.0.30001390"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001390.tgz"
+  integrity sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==
 
 captains-log@^2.0.2:
   version "2.0.3"
@@ -9993,6 +10010,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -11099,7 +11123,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0:
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -11114,17 +11138,22 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint@^6.6.0:
   version "6.8.0"
@@ -11573,6 +11602,17 @@ fast-glob@^3.2.4:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -12609,6 +12649,18 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.0.3:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
@@ -13433,6 +13485,11 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.1.8, ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 immer@1.10.0:
   version "1.10.0"
@@ -16625,7 +16682,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -21031,7 +21088,7 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.0.0:
+regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -21766,6 +21823,13 @@ semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.5:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -24052,7 +24116,7 @@ tsscmp@1.0.6:
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
-tsutils@^3.17.1:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
## Summary
Close #18 

No front-end, essa PR altera as paginas de erro para não usar mais o erro 401 (autenticação) como o erro padrão, evitando confundir os usuários com mensagens de erro sem sentido.

No back-end, essa PR traduz algumas strings enviadas pela API em caso de erro [WIP]

## Test Plan? 
Não há testes para mensagens de erro estarem em português

## Need help?
Nope
